### PR TITLE
feat(users): display user list and setup API proxy

### DIFF
--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -30,6 +30,7 @@ export class UserController {
   }
 
   @Get()
+  // @UseGuards(AuthGuard('jwt'))
   async getUsers() {
     return this.userService.getAllUsers();
   }

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
     }
     return config;
   },
+
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://backend:3000/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/users/page.tsx
+++ b/frontend/src/app/users/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface User {
+    id: number;
+    name: string;
+    email: string;
+}
+
+export default function UsersPage() {
+    const [users, setUsers] = useState<User[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        async function fetchUsers() {
+            try {
+                const response = await fetch("/api/users");
+                if (!response.ok) throw new Error("Failed to fetch users.");
+                
+                const data = await response.json();
+                setUsers(data);
+            } catch (error) {
+                console.log("Error fetching users:", error);
+                setError("Failed to load users. Please try again.")
+            } finally {
+                setLoading(false);
+            }
+        }
+        fetchUsers();
+    }, []);
+
+    return (
+        <div className="p-6">
+          <h1 className="text-2xl font-bold mb-4">User List</h1>
+    
+          {/* Display Error Message */}
+          {error && <p className="text-red-500">{error}</p>}
+    
+          {/* Loading State */}
+          {loading && <p>Loading...</p>}
+    
+          {/* Render Users if No Error */}
+          {!loading && !error && (
+            <ul className="list-disc pl-6">
+              {users.map((user) => (
+                <li key={user.id} className="text-lg">
+                  {user.name} ({user.email})
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      );
+}


### PR DESCRIPTION
## 📌 Summary
This PR adds the `/users` page and sets up API proxying for local development, allowing the frontend to dynamically fetch and display users.

## ✨ Changes Made
- **Implemented `/users` page (`page.tsx`)**
  - Fetches user data from the backend.
  - Displays a list of users with their names and emails.
  - Shows a loading state while data is being fetched.
  - Handles errors gracefully by displaying an error message.
- **Fixed Fetch Request**
  - Updated `fetchUsers()` to call `/api/users` instead of `http://localhost:3000/users`.
  - This prevents CORS issues and makes the API call environment-agnostic.
- **Updated `next.config.ts`**
  - Added API rewrites to proxy `/api/:path*` to `http://backend:3000/:path*` in Docker.
  - Allows the frontend to communicate with the backend without hardcoded URLs.

## 🚀 How to Test
1. **Start the project**
```
docker compose down -v
docker compose build 
docker compose up -d
```
2. **Create Users in your database**
```
http://localhost:3000/api/docs/
{
  "email": "test@example.com",
  "password": "password123",
  "role": "USER"
}
```
3. **Visit the Users Page**
- Open `localhost:5173/users`
- Ensure that the users are displayed correctly.
- If the backend is down, an error message should appear.